### PR TITLE
CLI overrides for MCTS params and verbose decision logging

### DIFF
--- a/Mage.MageZero/src/main/java/org/mage/magezero/Config.java
+++ b/Mage.MageZero/src/main/java/org/mage/magezero/Config.java
@@ -77,10 +77,10 @@ public class Config {
     }
 
     public static class PriorsConfig {
-        public final boolean priority;
-        public final boolean target;
-        public final boolean binary;
-        public final boolean opponent;
+        public boolean priority;
+        public boolean target;
+        public boolean binary;
+        public boolean opponent;
 
         public PriorsConfig(Map<String, Object> raw) {
             this.priority = (boolean) raw.getOrDefault("priority", false);
@@ -91,7 +91,7 @@ public class Config {
     }
 
     public static class NoiseConfig {
-        public final boolean enabled;
+        public boolean enabled;
 
         public NoiseConfig(Map<String, Object> raw) {
             this.enabled = (boolean) raw.getOrDefault("enabled", false);

--- a/Mage.MageZero/src/main/java/org/mage/magezero/ParallelDataGenerator.java
+++ b/Mage.MageZero/src/main/java/org/mage/magezero/ParallelDataGenerator.java
@@ -175,8 +175,6 @@ public class ParallelDataGenerator {
 
     }
     public void generateData() {
-        Logger.getLogger("org.mage.magezero.ParallelDataGenerator").setLevel(Level.ERROR);
-        Logger.getRootLogger().setLevel(Level.ERROR);
         PerfStats.reset();
 
         loadAllFiles();

--- a/Mage.MageZero/src/main/java/org/mage/magezero/ParallelDataGenerator.java
+++ b/Mage.MageZero/src/main/java/org/mage/magezero/ParallelDataGenerator.java
@@ -175,6 +175,7 @@ public class ParallelDataGenerator {
 
     }
     public void generateData() {
+        Logger.getRootLogger().setLevel(Level.WARN);
         PerfStats.reset();
 
         loadAllFiles();

--- a/Mage.Server.Plugins/Mage.Player.AI.RL/src/mage/player/ai/ComputerPlayerMCTS2.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.RL/src/mage/player/ai/ComputerPlayerMCTS2.java
@@ -273,7 +273,6 @@ public class ComputerPlayerMCTS2 extends ComputerPlayerMCTS {
     @Override
     protected MCTSNode calculateActions(Game game, ActionEncoder.ActionType action) {
         applyMCTS(game, action);
-
         MCTSNode best = root.bestChild(game);
         if(best == null) {
             logger.error("no best child");

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/ComputerPlayerMCTS.java
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/ComputerPlayerMCTS.java
@@ -54,6 +54,7 @@ public class ComputerPlayerMCTS extends ComputerPlayer {
     public static double C_PUCT = 1;
     //adjust based on available RAM and threads running
     public static int MAX_TREE_NODES = 100000;
+    public static boolean verbose = false;
 
     public transient MCTSNode root;
 

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/MCTSNode.java
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/MCTSNode.java
@@ -547,31 +547,42 @@ public class MCTSNode {
         if (children.size() == 1) {
             return children.get(0);
         }
-        StringBuilder sb = new StringBuilder();
-        if(baseGame.getTurnStepType() == null) {
-            sb.append("pre-game");
-        } else {
-            sb.append(baseGame.getTurnStepType().toString());
-        }
-        sb.append(baseGame.getStack().toString());
-        sb.append("pool=").append(myPlayer.getManaPool().getMana());
-        sb.append(" actions: ");
-        for (MCTSNode node: children) {
-            if(node.targetAction != null) {
-                sb.append(String.format("[%s score: %.3f count: %d] ", baseGame.getEntityName(node.targetAction, targetPlayer), node.getMeanScore(), node.getVisits()));
-            } else if(node.choiceAction != null) {
-                sb.append(String.format("[%s score: %.3f count: %d] ", node.choiceAction, node.getMeanScore(), node.getVisits()));
-            } else if(node.useAction != null) {
-                sb.append(String.format("[%s score: %.3f count: %d] ", node.useAction, node.getMeanScore(), node.getVisits()));
-            } else if(node.amountAction != null) {
-                sb.append(String.format("[%s score: %.3f count: %d] ", node.amountAction, node.getMeanScore(), node.getVisits()));
-            } else if(node.priorityAction != null){
-                sb.append(String.format("[%s score: %.3f count: %d] ", node.priorityAction, node.getMeanScore(), node.getVisits()));
-            } else {
-                logger.error("no action in node");
+        if(!children.isEmpty() && ComputerPlayerMCTS.verbose) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("\n  DECISION [");
+            sb.append(actionType != null ? actionType : "?");
+            sb.append("] turn=").append(baseGame.getTurnNum());
+            sb.append(" step=");
+            sb.append(baseGame.getTurnStepType() != null ? baseGame.getTurnStepType() : "pre-game");
+            if(!baseGame.getStack().isEmpty()) {
+                sb.append(" stack=").append(baseGame.getStack());
             }
-        }
-        if(!children.isEmpty() && !myPlayer.allMana) {
+            sb.append(" pool=").append(myPlayer.getManaPool().getMana());
+            sb.append(" value=").append(String.format("%.3f", this.networkScore));
+            sb.append("\n");
+
+            double sqrtN = Math.sqrt(getVisits());
+            children.sort(Comparator.comparingInt(MCTSNode::getVisits).reversed());
+            for (MCTSNode node : children) {
+                String actionName;
+                if (node.targetAction != null) {
+                    actionName = baseGame.getEntityName(node.targetAction, targetPlayer);
+                } else if (node.choiceAction != null) {
+                    actionName = node.choiceAction;
+                } else if (node.useAction != null) {
+                    actionName = node.useAction.toString();
+                } else if (node.amountAction != null) {
+                    actionName = node.amountAction.toString();
+                } else if (node.priorityAction != null) {
+                    actionName = node.priorityAction.toString();
+                } else {
+                    actionName = "???";
+                }
+                double q = node.getVisits() > 0 ? node.getMeanScore() : 0.0;
+                double u = ComputerPlayerMCTS.C_PUCT * node.prior * (sqrtN / (1 + node.getVisits()));
+                sb.append(String.format("    %-60s visits=%-5d Q=%.3f prior=%.3f U=%.3f\n",
+                        actionName, node.getVisits(), q, node.prior, u));
+            }
             logger.info(sb.toString());
         }
         //derive temp from value

--- a/Mage.Tests/src/test/java/org/mage/test/AI/KrenkoMain.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/KrenkoMain.java
@@ -3,6 +3,7 @@ package org.mage.test.AI;
 import org.mage.magezero.Config;
 
 import mage.cards.repository.CardRepository;
+import mage.player.ai.ComputerPlayerMCTS;
 import mage.cards.repository.CardScanner;
 import mage.cards.repository.RepositoryUtil;
 import org.mage.magezero.ParallelDataGenerator;
@@ -41,6 +42,11 @@ public class KrenkoMain {
         private String playerBType = "mcts";
         private String outputDir = "data";
         private int version = 0;
+        private Integer searchBudget = null;
+        private Integer timeoutMs = null;
+        private Boolean priors = null;
+        private Boolean noise = null;
+        private boolean verbose = false;
     }
 
     private static Options parseArgs(String[] args) {
@@ -80,6 +86,21 @@ public class KrenkoMain {
                     break;
                 case "--output-dir":
                     options.outputDir = args[++i];
+                    break;
+                case "--search-budget":
+                    options.searchBudget = Integer.parseInt(args[++i]);
+                    break;
+                case "--timeout-ms":
+                    options.timeoutMs = Integer.parseInt(args[++i]);
+                    break;
+                case "--priors":
+                    options.priors = Boolean.parseBoolean(args[++i]);
+                    break;
+                case "--noise":
+                    options.noise = Boolean.parseBoolean(args[++i]);
+                    break;
+                case "--verbose":
+                    options.verbose = true;
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + arg);
@@ -141,6 +162,29 @@ public class KrenkoMain {
                 Config.INSTANCE.training.games = options.gamesPerTest;
                 Config.INSTANCE.training.maxTurns = options.maxTurns;
                 Config.INSTANCE.training.threads = options.threads;
+                if (options.searchBudget != null) {
+                    Config.INSTANCE.playerA.mcts.searchBudget = options.searchBudget;
+                    Config.INSTANCE.playerB.mcts.searchBudget = options.searchBudget;
+                }
+                if (options.timeoutMs != null) {
+                    Config.INSTANCE.playerA.mcts.timeoutMs = options.timeoutMs;
+                    Config.INSTANCE.playerB.mcts.timeoutMs = options.timeoutMs;
+                }
+                if (options.priors != null) {
+                    Config.INSTANCE.playerA.priors.priority = options.priors;
+                    Config.INSTANCE.playerA.priors.target = options.priors;
+                    Config.INSTANCE.playerA.priors.binary = options.priors;
+                    Config.INSTANCE.playerA.priors.opponent = options.priors;
+                    Config.INSTANCE.playerB.priors.priority = options.priors;
+                    Config.INSTANCE.playerB.priors.target = options.priors;
+                    Config.INSTANCE.playerB.priors.binary = options.priors;
+                    Config.INSTANCE.playerB.priors.opponent = options.priors;
+                }
+                if (options.noise != null) {
+                    Config.INSTANCE.playerA.noise.enabled = options.noise;
+                    Config.INSTANCE.playerB.noise.enabled = options.noise;
+                }
+                ComputerPlayerMCTS.verbose = options.verbose;
                 try {
                     long generatorStartTime = System.nanoTime();
                     ParallelDataGenerator generator = new ParallelDataGenerator();

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,16 @@ install: clean build
 DECK    ?= decks/IzzetElementals.dck
 OP_DECK ?= decks/MonoRAggro.dck
 
+KRENKO_JAR ?= Mage.Tests/target/mage-tests.jar
+
+.PHONY: build-krenko-jar
+build-krenko-jar:
+	mvn -pl Mage.Tests -am -DskipTests package
+
 .PHONY: run-krenko
-run-krenko:
-	mvn -pl Mage.Tests exec:java \
-		-Dexec.mainClass="org.mage.test.AI.KrenkoMain" \
-		-Dexec.classpathScope=test \
-		-Dexec.args="--player-deck $(DECK) --opponent-deck $(OP_DECK)"
+run-krenko: build-krenko-jar
+	java --enable-native-access=ALL-UNNAMED -jar $(KRENKO_JAR) \
+		--player-deck $(DECK) --opponent-deck $(OP_DECK)
 		
 
 
@@ -63,4 +67,3 @@ run-server:
 run-client:
 	cd Mage.Client && mvn exec:java \
 		-Dexec.mainClass="mage.client.MageFrame"
-


### PR DESCRIPTION
## Summary
- Add `--search-budget`, `--timeout-ms`, `--priors`, `--noise`, `--verbose` CLI args to KrenkoMain
- Verbose mode logs MCTS decision details (actions, visit counts, Q-values, priors, PUCT scores) at each decision point
- Make PriorsConfig and NoiseConfig fields mutable so they can be overridden after config load
- Set game simulation log level to WARN (was ERROR, which hid warnings; was previously overriding to ERROR from the log4j.properties INFO default)
- Update Makefile to use shaded jar instead of mvn exec:java

## Test plan
- [x] Verified `--verbose` shows decision logs via `generate-data`
- [x] Verified logs are suppressed without `--verbose`
- [x] Verified `--search-budget` override works end-to-end
- [x] Tested in Docker batch image on AWS Batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)